### PR TITLE
Add column filters, table fixed height and other minor changes

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -40,7 +40,9 @@ angular.module('adaptv.adaptStrap', [
         response: {
           itemsLocation: 'data',
           totalItems: 'pagination.totalCount'
-        }
+        },
+        pageSize: 10,
+        pageSizes: [10,25,50]
       };
     this.$get = function () {
       return {

--- a/src/module.js
+++ b/src/module.js
@@ -42,7 +42,7 @@ angular.module('adaptv.adaptStrap', [
           totalItems: 'pagination.totalCount'
         },
         pageSize: 10,
-        pageSizes: [10,25,50]
+        pageSizes: [10, 25, 50]
       };
     this.$get = function () {
       return {

--- a/src/tableajax/tableajax.js
+++ b/src/tableajax/tableajax.js
@@ -18,8 +18,8 @@ angular.module('adaptv.adaptStrap.tableajax', ['adaptv.adaptStrap.utils', 'adapt
             currentPage: 1,
             totalPages: undefined,
             totalItems: undefined,
-            pageSize: Number($attrs.pageSize) || 10,
-            pageSizes: $parse($attrs.pageSizes)() || [10, 25, 50]
+            pageSize: Number($attrs.pageSize) || $adConfig.paging.pageSize,
+            pageSizes: $parse($attrs.pageSizes)() || $adConfig.paging.pageSizes
           }
         };
         $scope.localConfig = {

--- a/src/tablelite/headerRowContent.html
+++ b/src/tablelite/headerRowContent.html
@@ -8,6 +8,7 @@
     ng-if="attrs.selectedItems && items.allItems">
   <input type="checkbox"
          class="ad-cursor-pointer"
+         ng-if="!attrs.enableFiltering"
          ng-click="adStrapUtils.addRemoveItemsFromList(items.allItems, selectedItems)"
          ng-checked="adStrapUtils.itemsExistInList(items.allItems, selectedItems)">
 </th>

--- a/src/tablelite/headerRowContent.html
+++ b/src/tablelite/headerRowContent.html
@@ -12,7 +12,7 @@
          ng-click="adStrapUtils.addRemoveItemsFromList(items.allItems, selectedItems)"
          ng-checked="adStrapUtils.itemsExistInList(items.allItems, selectedItems)">
 </th>
-<th data-ng-repeat="definition in columnDefinition"
+<th data-ng-repeat="definition in columnDefinition | filter:columnVisible"
     ng-click="sortByColumn(definition)"
     ng-class="{'ad-cursor-pointer': definition.sortKey}"
     ng-style="{'width': definition.width}">

--- a/src/tablelite/headerRowContent.html
+++ b/src/tablelite/headerRowContent.html
@@ -8,7 +8,7 @@
     ng-if="attrs.selectedItems && items.allItems">
   <input type="checkbox"
          class="ad-cursor-pointer"
-         ng-if="!attrs.enableFiltering"
+         ng-if="!attrs.enableColumnSearch"
          ng-click="adStrapUtils.addRemoveItemsFromList(items.allItems, selectedItems)"
          ng-checked="adStrapUtils.itemsExistInList(items.allItems, selectedItems)">
 </th>

--- a/src/tablelite/headerRowFilterContent.html
+++ b/src/tablelite/headerRowFilterContent.html
@@ -1,0 +1,20 @@
+<th class="ad-select-cell" ng-if="attrs.draggable">
+    <i></i>
+</th>
+<th class="ad-select-cell" ng-if="attrs.rowExpandTemplate">
+    <i></i>
+</th>
+<th class="ad-select-cell"
+    ng-if="attrs.selectedItems && items.allItems">
+  <input type="checkbox"
+         class="ad-cursor-pointer"
+         ng-if="attrs.enableFiltering"
+         ng-click="adStrapUtils.addRemoveItemsFromList(items.allItems, selectedItems)"
+         ng-checked="adStrapUtils.itemsExistInList(items.allItems, selectedItems)">
+</th>
+<th data-ng-repeat="definition in columnDefinition">
+    <input ng-if="definition.enableFiltering !== false"
+           type="text"
+           class="input-sm form-control"
+           ng-model="filters[definition.displayProperty]" />
+</th>

--- a/src/tablelite/headerRowFilterContent.html
+++ b/src/tablelite/headerRowFilterContent.html
@@ -12,7 +12,7 @@
          ng-click="adStrapUtils.addRemoveItemsFromList(items.allItems, selectedItems)"
          ng-checked="adStrapUtils.itemsExistInList(items.allItems, selectedItems)">
 </th>
-<th data-ng-repeat="definition in columnDefinition">
+<th data-ng-repeat="definition in columnDefinition | filter:columnVisible">
     <input ng-if="definition.enableFiltering !== false"
            type="text"
            class="input-sm form-control"

--- a/src/tablelite/headerRowFilterContent.html
+++ b/src/tablelite/headerRowFilterContent.html
@@ -8,7 +8,7 @@
     ng-if="attrs.selectedItems && items.allItems">
   <input type="checkbox"
          class="ad-cursor-pointer"
-         ng-if="attrs.enableFiltering"
+         ng-if="attrs.enableColumnSearch"
          ng-click="adStrapUtils.addRemoveItemsFromList(items.allItems, selectedItems)"
          ng-checked="adStrapUtils.itemsExistInList(items.allItems, selectedItems)">
 </th>

--- a/src/tablelite/headerRowFilterContent.html
+++ b/src/tablelite/headerRowFilterContent.html
@@ -13,8 +13,8 @@
          ng-checked="adStrapUtils.itemsExistInList(items.allItems, selectedItems)">
 </th>
 <th data-ng-repeat="definition in columnDefinition | filter:columnVisible">
-    <input ng-if="definition.enableFiltering !== false"
+    <input ng-if="definition.columnSearchProperty"
            type="text"
            class="input-sm form-control"
-           ng-model="filters[definition.displayProperty]" />
+           ng-model="filters[definition.columnSearchProperty]" />
 </th>

--- a/src/tablelite/pagination.html
+++ b/src/tablelite/pagination.html
@@ -45,14 +45,6 @@
         </a>
       </li>
       <li>
-        <a ng-if="!attrs.draggable"
-           class="ad-cursor-pointer"
-           ng-click="loadNextPage()"
-           ng-disabled="items.paging.currentPage == items.paging.totalPages">
-          <i ng-class="iconClasses.nextPage"></i>
-        </a>
-      </li>
-      <li>
         <a id="btnNext"
            class="ad-cursor-pointer"
            ng-if="attrs.draggable"

--- a/src/tablelite/pagination.html
+++ b/src/tablelite/pagination.html
@@ -1,4 +1,4 @@
-<div class="row"
+<div class="row ad-table-pagination-container"
      ng-if="items.allItems.length > items.paging.pageSizes[0] && !attrs.disablePaging">
   <div class="col-md-8 col-sm-8 text-left">
     <ul ng-class="attrs.paginationBtnGroupClasses || 'pagination pagination-sm'">

--- a/src/tablelite/rowContent.html
+++ b/src/tablelite/rowContent.html
@@ -13,7 +13,7 @@
          ng-checked="adStrapUtils.itemExistsInList(item, selectedItems)"
          ng-click="adStrapUtils.addRemoveItemFromList(item, selectedItems)">
 </td>
-<td data-ng-repeat="definition in columnDefinition"
+<td data-ng-repeat="definition in columnDefinition | filter:columnVisible"
     ng-style="{'width': definition.width}">
   <div ng-if="definition.templateUrl">
     <ng-include src="definition.templateUrl"></ng-include>

--- a/src/tablelite/tablelite.js
+++ b/src/tablelite/tablelite.js
@@ -119,6 +119,10 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
           $scope.loadPage(1);
         };
 
+        $scope.columnVisible = function(column) {
+          return column.visible !== false;
+        };
+        
         $scope.sortByColumn = function (column) {
           var initialSortDirection = true;
           if ($attrs.onClickSortDirection === 'DEC') {

--- a/src/tablelite/tablelite.js
+++ b/src/tablelite/tablelite.js
@@ -92,6 +92,8 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
           $scope.items.paging.currentPage = response.currentPage;
           $scope.items.paging.totalPages = response.totalPages;
           $scope.localConfig.pagingArray = response.pagingArray;
+          
+          $scope.$emit('adTableLite:pageChanged', $scope.items.paging);
         }, 100);
 
         $scope.loadNextPage = function () {

--- a/src/tablelite/tablelite.js
+++ b/src/tablelite/tablelite.js
@@ -69,7 +69,7 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
               params,
               parsedData = adStrapUtils.parse($scope.$eval($attrs.localDataSource));
 
-          $scope.localConfig.localData = $filter('filter')(parsedData, $scope.searchText);
+          $scope.localConfig.localData = !!$scope.searchText ? $filter('filter')(parsedData, $scope.searchText) : parsedData;
           itemsObject = $scope.localConfig.localData;
           params = {
             pageNumber: page,
@@ -256,7 +256,7 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
         watchers.push(
           $scope.$watch($attrs.searchText, function() {
             $scope.searchText = $scope.$eval($attrs.searchText);
-            $scope.loadPage($scope.items.paging.currentPage);
+            $scope.loadPage(1);
           })
         );
 

--- a/src/tablelite/tablelite.js
+++ b/src/tablelite/tablelite.js
@@ -27,6 +27,8 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
           }
         };
 
+        $scope.filters = {};
+        
         $scope.localConfig = {
           localData: adStrapUtils.parse($scope.$eval($attrs.localDataSource)),
           pagingArray: [],
@@ -70,6 +72,11 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
               parsedData = adStrapUtils.parse($scope.$eval($attrs.localDataSource));
 
           $scope.localConfig.localData = !!$scope.searchText ? $filter('filter')(parsedData, $scope.searchText) : parsedData;
+          
+          if ($attrs.enableFiltering && adStrapUtils.hasAtLeastOnePropertyWithValue($scope.filters)) {
+            $scope.localConfig.localData = $filter('filter')($scope.localConfig.localData, $scope.filters);
+          }
+        
           itemsObject = $scope.localConfig.localData;
           params = {
             pageNumber: page,
@@ -260,6 +267,15 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
           })
         );
 
+        if ($attrs.enableFiltering) {
+          var loadFilterPage = adDebounce(function() {
+            $scope.loadPage(1);
+          }, Number($attrs.filterDebounce) || 400);
+          watchers.push($scope.$watch('filters', function () {
+            loadFilterPage();
+          }, true));
+        }
+      
         // ---------- disable watchers ---------- //
         $scope.$on('$destroy', function () {
           watchers.forEach(function (watcher) {

--- a/src/tablelite/tablelite.js
+++ b/src/tablelite/tablelite.js
@@ -73,7 +73,7 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
 
           $scope.localConfig.localData = !!$scope.searchText ? $filter('filter')(parsedData, $scope.searchText) : parsedData;
           
-          if ($attrs.enableFiltering && adStrapUtils.hasAtLeastOnePropertyWithValue($scope.filters)) {
+          if ($attrs.enableColumnSearch && adStrapUtils.hasAtLeastOnePropertyWithValue($scope.filters)) {
             $scope.localConfig.localData = $filter('filter')($scope.localConfig.localData, $scope.filters);
           }
         
@@ -273,10 +273,10 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
           })
         );
 
-        if ($attrs.enableFiltering) {
+        if ($attrs.enableColumnSearch) {
           var loadFilterPage = adDebounce(function() {
             $scope.loadPage(1);
-          }, Number($attrs.filterDebounce) || 400);
+          }, Number($attrs.columnSearchDebounce) || 400);
           watchers.push($scope.$watch('filters', function () {
             loadFilterPage();
           }, true));

--- a/src/tablelite/tablelite.js
+++ b/src/tablelite/tablelite.js
@@ -22,8 +22,8 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
           paging: {
             currentPage: 1,
             totalPages: undefined,
-            pageSize: Number($attrs.pageSize) || 10,
-            pageSizes: $parse($attrs.pageSizes)() || [10, 25, 50]
+            pageSize: Number($attrs.pageSize) || $adConfig.paging.pageSize,
+            pageSizes: $parse($attrs.pageSizes)() || $adConfig.paging.pageSizes
           }
         };
 

--- a/src/tablelite/tablelite.js
+++ b/src/tablelite/tablelite.js
@@ -28,7 +28,7 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
         };
 
         $scope.filters = {};
-        
+
         $scope.localConfig = {
           localData: adStrapUtils.parse($scope.$eval($attrs.localDataSource)),
           pagingArray: [],
@@ -71,12 +71,14 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
               params,
               parsedData = adStrapUtils.parse($scope.$eval($attrs.localDataSource));
 
-          $scope.localConfig.localData = !!$scope.searchText ? $filter('filter')(parsedData, $scope.searchText) : parsedData;
-          
+          $scope.localConfig.localData = !!$scope.searchText ?
+            $filter('filter')(parsedData, $scope.searchText) :
+            parsedData;
+
           if ($attrs.enableColumnSearch && adStrapUtils.hasAtLeastOnePropertyWithValue($scope.filters)) {
             $scope.localConfig.localData = $filter('filter')($scope.localConfig.localData, $scope.filters);
           }
-        
+
           itemsObject = $scope.localConfig.localData;
           params = {
             pageNumber: page,
@@ -92,7 +94,7 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
           $scope.items.paging.currentPage = response.currentPage;
           $scope.items.paging.totalPages = response.totalPages;
           $scope.localConfig.pagingArray = response.pagingArray;
-          
+
           $scope.$emit('adTableLite:pageChanged', $scope.items.paging);
         }, 100);
 
@@ -122,7 +124,7 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
         $scope.columnVisible = function(column) {
           return column.visible !== false;
         };
-        
+
         $scope.sortByColumn = function (column) {
           var initialSortDirection = true;
           if ($attrs.onClickSortDirection === 'DEC') {
@@ -281,7 +283,7 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
             loadFilterPage();
           }, true));
         }
-      
+
         // ---------- disable watchers ---------- //
         $scope.$on('$destroy', function () {
           watchers.forEach(function (watcher) {

--- a/src/tablelite/tablelite.tpl.html
+++ b/src/tablelite/tablelite.tpl.html
@@ -4,7 +4,7 @@
          ng-class="{'ad-fixed-layout': (attrs.tableMaxHeight || attrs.tableFixedHeight)}">
     <thead>
       <tr class="ad-user-select-none" ng-include="'tablelite/headerRowContent.html'"></tr>
-      <tr class="ad-user-select-none" ng-if="attrs.enableFiltering" ng-include="'tablelite/headerRowFilterContent.html'"></tr>
+      <tr class="ad-user-select-none" ng-if="attrs.enableColumnSearch" ng-include="'tablelite/headerRowFilterContent.html'"></tr>
     </thead>
   </table>
   <div class="ad-table-container" ng-style="{'max-height': attrs.tableMaxHeight, 'height': attrs.tableFixedHeight}">
@@ -12,7 +12,7 @@
            ng-class="{'ad-fixed-layout': (attrs.tableMaxHeight || attrs.tableFixedHeight)}">
       <thead>
         <tr class="ad-user-select-none" ng-if="!(attrs.tableMaxHeight || attrs.tableFixedHeight)" ng-include="'tablelite/headerRowContent.html'"></tr>
-        <tr class="ad-user-select-none" ng-if="!(attrs.tableMaxHeight || attrs.tableFixedHeight) && attrs.enableFiltering" ng-include="'tablelite/headerRowFilterContent.html'"></tr>    
+        <tr class="ad-user-select-none" ng-if="!(attrs.tableMaxHeight || attrs.tableFixedHeight) && attrs.enableColumnSearch" ng-include="'tablelite/headerRowFilterContent.html'"></tr>    
       </thead>
       <tbody ng-if="!attrs.draggable" ng-include="'tablelite/defaultRow.html'"></tbody>
       <tbody ng-if="attrs.draggable" ng-include="'tablelite/draggableRow.html'"></tbody>

--- a/src/tablelite/tablelite.tpl.html
+++ b/src/tablelite/tablelite.tpl.html
@@ -4,6 +4,7 @@
          ng-class="{'ad-fixed-layout': (attrs.tableMaxHeight || attrs.tableFixedHeight)}">
     <thead>
       <tr class="ad-user-select-none" ng-include="'tablelite/headerRowContent.html'"></tr>
+      <tr class="ad-user-select-none" ng-if="attrs.enableFiltering" ng-include="'tablelite/headerRowFilterContent.html'"></tr>
     </thead>
   </table>
   <div class="ad-table-container" ng-style="{'max-height': attrs.tableMaxHeight, 'height': attrs.tableFixedHeight}">
@@ -11,6 +12,7 @@
            ng-class="{'ad-fixed-layout': (attrs.tableMaxHeight || attrs.tableFixedHeight)}">
       <thead>
         <tr class="ad-user-select-none" ng-if="!(attrs.tableMaxHeight || attrs.tableFixedHeight)" ng-include="'tablelite/headerRowContent.html'"></tr>
+        <tr class="ad-user-select-none" ng-if="!(attrs.tableMaxHeight || attrs.tableFixedHeight) && attrs.enableFiltering" ng-include="'tablelite/headerRowFilterContent.html'"></tr>    
       </thead>
       <tbody ng-if="!attrs.draggable" ng-include="'tablelite/defaultRow.html'"></tbody>
       <tbody ng-if="attrs.draggable" ng-include="'tablelite/draggableRow.html'"></tbody>

--- a/src/tablelite/tablelite.tpl.html
+++ b/src/tablelite/tablelite.tpl.html
@@ -1,16 +1,16 @@
 <div class="ad-table-lite-container" ng-if="items.allItems.length || !attrs.itemsNotFoundMessage">
   <table class="ad-sticky-table {{ attrs.tableClasses || 'table' }}"
-         ng-if="attrs.tableMaxHeight"
-         ng-class="{'ad-fixed-layout': attrs.tableMaxHeight}">
+         ng-if="attrs.tableMaxHeight || attrs.tableFixedHeight"
+         ng-class="{'ad-fixed-layout': (attrs.tableMaxHeight || attrs.tableFixedHeight)}">
     <thead>
       <tr class="ad-user-select-none" ng-include="'tablelite/headerRowContent.html'"></tr>
     </thead>
   </table>
-  <div class="ad-table-container" ng-style="{'max-height': attrs.tableMaxHeight}">
+  <div class="ad-table-container" ng-style="{'max-height': attrs.tableMaxHeight, 'height': attrs.tableFixedHeight}">
     <table class="{{ attrs.tableClasses || 'table' }}"
-           ng-class="{'ad-fixed-layout': attrs.tableMaxHeight}">
+           ng-class="{'ad-fixed-layout': (attrs.tableMaxHeight || attrs.tableFixedHeight)}">
       <thead>
-        <tr class="ad-user-select-none" ng-if="!attrs.tableMaxHeight" ng-include="'tablelite/headerRowContent.html'"></tr>
+        <tr class="ad-user-select-none" ng-if="!(attrs.tableMaxHeight || attrs.tableFixedHeight)" ng-include="'tablelite/headerRowContent.html'"></tr>
       </thead>
       <tbody ng-if="!attrs.draggable" ng-include="'tablelite/defaultRow.html'"></tbody>
       <tbody ng-if="attrs.draggable" ng-include="'tablelite/draggableRow.html'"></tbody>

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -119,11 +119,15 @@ angular.module('adaptv.adaptStrap.utils', [])
         for (name in obj) {
           value = obj[name];
           if (value instanceof Array) {
-            if (value.length > 0) has = true;
+            if (value.length > 0) {
+              has = true;
+            }
           } else if (!!value) {
             has = true;
           }
-          if (has) break;
+          if (has) {
+            break;
+          }
         }
         return has;
       };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -114,6 +114,18 @@ angular.module('adaptv.adaptStrap.utils', [])
           item = item[arr.shift()];
         }
         return item;
+      }, hasAtLeastOnePropertyWithValue = function (obj) {
+        var has = false, name, value;
+        for (name in obj) {
+          value = obj[name];
+          if (value instanceof Array) {
+            if (value.length > 0) has = true;
+          } else if (!!value) {
+            has = true;
+          }
+          if (has) break;
+        }
+        return has;
       };
 
     return {
@@ -128,7 +140,8 @@ angular.module('adaptv.adaptStrap.utils', [])
       addRemoveItemsFromList: addRemoveItemsFromList,
       moveItemInList: moveItemInList,
       parse: parse,
-      getObjectProperty: getObjectProperty
+      getObjectProperty: getObjectProperty,
+      hasAtLeastOnePropertyWithValue: hasAtLeastOnePropertyWithValue
     };
 
   }])


### PR DESCRIPTION
First off, table lite is great. Hard to find, but works awesome. I made a few additions to meet our needs I thought I might pass along in the hope others could use them. I made individual commits so you could cherry pick you want.

Changes
- Added default pageSize/pageSizes to $adConfig.paging so they can be set once across all views
- Removed an extra "next page" button from pagination.html
- Added a check to see if searchText had a value before calling filter
- Changed the search to always go to page 1. If you are on a page that is less than the results, no rows show up and all the paging controls go away
  - You can see this on the demo page, go to page 2, then search for S8
- Added a css class to the paging container for styling
- Added table-fixed-height as an option, like table-max-height, it causes the table to scroll, but keeps it at a constant size. This helps if you have 2 or 3 tables stacked and they all stay in the same place.
- Emit an event whenever a page changes 'adTableLite:pageChanged'. We wanted to clear the selected items when the page changes.
- Added filters per column that work in addition to the gobal searchText. Usage...
  - set enable-filtering="true"
  - optionally set filter-debounce="400" to change the default debounce of 400
  - each column will output a text box unless you specify enableFiltering: false on the column definition
    - Another option here would be to specify a filterKey on each column definition to opt in, which would be more like sortKey
  - when filter is enabled, the selection checkbox is moved down to the filter row

screen shot of filters


![image](https://cloud.githubusercontent.com/assets/1154287/5983391/71bdb478-a892-11e4-9073-530b10513960.png)


Let me know if you have any questions. 

Brian