### PR TITLE
Fix tablelite bug, added custom-classes to alert

### DIFF
--- a/docs/modulesDefinitions.js
+++ b/docs/modulesDefinitions.js
@@ -7,7 +7,8 @@ angular.module('adaptv.adaptStrapDocs').constant('adaptStrapModules', [
     description: 'shows notification messages to the user.',
     docFiles: [
       'alerts.view.html',
-      'alerts.ctrl.js'
+      'alerts.ctrl.js',
+      'style.css'
     ],
     directives: [{
       name: 'ad-alerts',
@@ -17,6 +18,12 @@ angular.module('adaptv.adaptStrapDocs').constant('adaptStrapModules', [
         default: 'NA',
         type: 'String/Number',
         description: 'The number of milliseconds the alert is visible, before it auto closes'
+      }, {
+        name: 'custom-classes',
+        required: false,
+        default: 'NA',
+        type: 'String',
+        description: 'Allows the definition of custom styling for the alert'
       }]
     }]
   },

--- a/src/alerts/alerts.js
+++ b/src/alerts/alerts.js
@@ -19,6 +19,8 @@ angular.module('adaptv.adaptStrap.alerts', [])
         }
       };
 
+      $scope.customClasses = $scope.customClasses || '';
+
       $scope.settings = adAlerts.settings;
 
       if (timeout !== 0) {
@@ -35,7 +37,8 @@ angular.module('adaptv.adaptStrap.alerts', [])
     return {
       restrict: 'AE',
       scope: {
-        timeout: '=' //ms
+        timeout: '=', //ms
+        customClasses: '@'
       },
       templateUrl: 'alerts/alerts.tpl.html',
       controller: ['$scope', '$attrs', '$timeout', '$adConfig', 'adAlerts', controllerFunction]

--- a/src/alerts/alerts.tpl.html
+++ b/src/alerts/alerts.tpl.html
@@ -1,4 +1,4 @@
-<div ng-show="settings.type !== ''" class="alert alert-{{ settings.type }} alert-dismissible fade in" role="alert">
+<div ng-show="settings.type !== ''" class="alert alert-{{ settings.type }} alert-dismissible fade in {{ customClasses }}" role="alert">
   <button type="button" class="close" ng-click="close();" aria-label="Close">
     <span aria-hidden="true">&times;</span>
   </button>

--- a/src/alerts/docs/alerts.view.html
+++ b/src/alerts/docs/alerts.view.html
@@ -2,7 +2,7 @@
 <div ng-controller="alertCtrl">
   <!-- ad_example_start -->
   <!-- Usage: put this in your main app container -->
-  <ad-alerts timeout="timeoutValue"></ad-alerts>
+  <ad-alerts timeout="timeoutValue" custom-classes="thick-border"></ad-alerts>
   <!-- ad_example_end -->
   <br/>
   <!-- ad_example_start -->

--- a/src/alerts/docs/style.css
+++ b/src/alerts/docs/style.css
@@ -1,0 +1,3 @@
+.thick-border {
+  border-width: 6px; 
+}

--- a/src/tablelite/docs/tablelite.info.html
+++ b/src/tablelite/docs/tablelite.info.html
@@ -10,7 +10,7 @@
             cellFilter: 'String', // - Optional - the filter expression to apply to the displayProperty
             templateUrl: 'String', // - Not required if displayProperty is specified - look at artistPicture.html,
             template: 'String', // - Not required if displayProperty or templateUrl specified. - inline template string
-            sortKey: 'String', // - Optional - specified key (in most cases: same as displayProperty) will be used for sorting
+            sortKey: 'String || Function', // - Optional - specified key (in most cases: same as displayProperty) will be used for sorting
             width: 'String' // - Optional - the explicitly specify width of the column. (Ex: '10em', '30px'). If not specified, width is calculated automatically based on content width.
             visible: 'Boolean' // - Optional - hide column by setting this to false
         }

--- a/src/tablelite/tablelite.js
+++ b/src/tablelite/tablelite.js
@@ -43,6 +43,7 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
 
         // ---------- Local data ---------- //
         var placeHolder = null,
+          placeHolderInDom = false,
           pageButtonElement = null,
           validDrop = false,
           initialPos,
@@ -161,18 +162,23 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
           $scope.localConfig.expandedItems.length = 0;
           dragElement = dragElement.el;
           var parent = dragElement.parent();
-          placeHolder = $('<tr><td colspan=' + dragElement.find('td').length + '>&nbsp;</td></tr>');
+          placeHolder = $('<tr id="row-phldr"><td colspan=' + dragElement.find('td').length + '>&nbsp;</td></tr>');
           initialPos = dragElement.index() + (($scope.items.paging.currentPage - 1) *
             $scope.items.paging.pageSize);
-          if (dragElement[0] !== parent.children().last()[0]) {
-            dragElement.next().before(placeHolder);
-          } else {
-            parent.append(placeHolder);
+          if (!placeHolderInDom) {
+            if (dragElement[0] !== parent.children().last()[0]) {
+              dragElement.next().before(placeHolder);
+              placeHolderInDom = true;
+            } else {
+              parent.append(placeHolder);
+              placeHolderInDom = true;
+            }
           }
         };
 
         $scope.onDragEnd = function() {
-          placeHolder.remove();
+          $('#row-phldr').remove();
+          placeHolderInDom = false;
         };
 
         $scope.onDragOver = function(data, dragElement, dropElement) {
@@ -192,7 +198,10 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
             } else if (placeHolder.prev()[0]) {
               placeHolder.prev().after(dragElement);
             }
-            placeHolder.remove();
+
+            $('#row-phldr').remove();
+            placeHolderInDom = false;
+
             validDrop = true;
             endPos = dragElement.index() + (($scope.items.paging.currentPage - 1) *
               $scope.items.paging.pageSize);
@@ -231,7 +240,10 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
             }
             adStrapUtils.moveItemInList(initialPos, endPos, $scope.localConfig.localData);
             $scope.loadPage($scope.items.paging.currentPage);
-            placeHolder.remove();
+
+            $('#row-phldr').remove();
+            placeHolderInDom = false;
+
             dragElement.el.remove();
             if ($scope.localConfig.dragChange) {
               $scope.localConfig.dragChange(initialPos, endPos, data);


### PR DESCRIPTION
Fix for tablelite drag n drop bug
- This occurs if you click on the drag n drop icon for a row really fast. It adds an empty row each time.

Added custom-classes to alert component
- This allows a user add custom css for the alerts

Updated the documentation for the tablelite sortKey property. it can be a function.