### PR TITLE
Letting the user set up an initial sorting

### DIFF
--- a/src/tablelite/tablelite.js
+++ b/src/tablelite/tablelite.js
@@ -35,7 +35,9 @@ angular.module('adaptv.adaptStrap.tablelite', ['adaptv.adaptStrap.utils'])
           localData: adStrapUtils.parse($scope.$eval($attrs.localDataSource)),
           pagingArray: [],
           dragChange: $scope.$eval($attrs.onDragChange),
-          expandedItems: []
+          expandedItems: [],
+          predicate: $scope.$eval($attrs.sortKey),
+          reverse: $scope.$eval($attrs.sortDirection)
         };
 
         $scope.selectedItems = $scope.$eval($attrs.selectedItems);


### PR DESCRIPTION
Letting the user set up an initial sorting like:
<ad-table-lite
    sort-key="'status'"
    sort-direction="true"
</ad-table-lite>