### PR TITLE
Custom toggling and indentation for treebrowser

### DIFF
--- a/docs/modulesDefinitions.js
+++ b/docs/modulesDefinitions.js
@@ -523,6 +523,17 @@ angular.module('adaptv.adaptStrapDocs').constant('adaptStrapModules', [
           default: 'false',
           type: 'boolean',
           description: 'If true, adds border to the tree levels'
+        },
+        {
+          name: 'custom-toggle',
+          required: false,
+          default: 'false',
+          type: 'boolean',
+          description: 'If true, the default toggling functionality is disabled. A toggling directive, ' +
+            'ad-tree-browser-node-toggle, is used to provide toggling behavior, typically done in the node template. ' +
+            'One can also implement hierarchical structure using custom indentation. ' +
+            'See <a href="https://github.com/Adaptv/adapt-strap/blob/master/src/treebrowser/docs/treeNodeWithCustomToggle.html">' +
+            'treeNode sample</a>'
         }
       ]
     }]

--- a/src/treebrowser/docs/treeHeader.html
+++ b/src/treebrowser/docs/treeHeader.html
@@ -1,5 +1,5 @@
 <div>
-    <span class="name-cell pull-left">Name</span>
-    <span class="another-cell pull-left">Another Cell</span>
-    <span class="pull-right margin-right-lg">Price Range</span>
+    <div class="col-sm-3">Name</div>
+    <div class="col-sm-3">Another Cell</div>
+    <div class="col-sm-3">Price Range</div>
 </div>

--- a/src/treebrowser/docs/treeNodeWithCustomToggle.html
+++ b/src/treebrowser/docs/treeNodeWithCustomToggle.html
@@ -1,6 +1,9 @@
 <div>
-    <div class="col-sm-3">
-        {{item.name }}
+    <div class="col-sm-3"
+          ng-style="{'padding-left': level * 15 + 'px'}">
+        <ad-tree-browser-node-toggle>
+        </ad-tree-browser-node-toggle>{{
+        item.name }}
     </div>
     <div class="col-sm-3">Another Cell</div>
     <div class="col-sm-3">

--- a/src/treebrowser/docs/treebrowser.view.html
+++ b/src/treebrowser/docs/treebrowser.view.html
@@ -7,11 +7,12 @@
                    row-ng-class="{added:item._selected}"
                    tree-root="root"
                    child-node="children"
-                   children-padding="15"
+                   children-padding="0"
                    bordered="true"
                    on-row-click="rowClicked"
                    node-header-url="src/treebrowser/docs/treeHeader.html"
-                   node-template-url="src/treebrowser/docs/treeNode.html">
+                   node-template-url="src/treebrowser/docs/treeNodeWithCustomToggle.html"
+                   custom-toggle="true">
   </ad-tree-browser>
   <!-- ad_example_end -->
   <hr>

--- a/src/treebrowser/treeBrowserNode.tpl.html
+++ b/src/treebrowser/treeBrowserNode.tpl.html
@@ -3,17 +3,8 @@
      ng-click="onRowClick(item, level, $event)"
      ng-class="{{ attrs.rowNgClass }}">
     <div class="content-holder">
-        <div class="toggle">
-            <i ng-if="!item._ad_expanded && hasChildren(item) && !item._ad_loading"
-               ng-class="iconClasses.expand"
-               ng-click="toggle($event,item)"></i>
-            <i ng-if="item._ad_expanded && !item._ad_loading"
-               ng-class="iconClasses.collapse"
-               ng-click="toggle($event,item)"></i>
-            <span ng-if="item._ad_loading">
-                <i ng-class="iconClasses.loadingSpinner"></i>
-            </span>
-        </div>
+        <ad-tree-browser-node-toggle ng-if="!attrs.customToggle">
+        </ad-tree-browser-node-toggle>
         <div class="node-content">
             %=nodeTemplate%
             <span ng-if="!attrs.nodeTemplateUrl">{{ item.name || "" }}</span>

--- a/src/treebrowser/treebrowser.js
+++ b/src/treebrowser/treebrowser.js
@@ -73,4 +73,12 @@ angular.module('adaptv.adaptStrap.treebrowser', [])
         restrict: 'E'
       }
     }
-  ]);
+  ])
+  .directive('adTreeBrowserNodeToggle', function() {
+    return {
+      scope: true,
+      restrict: 'E',
+      replace: true,
+      templateUrl: 'treebrowser/treebrowserNodeToggle.tpl.html'
+    }
+  });

--- a/src/treebrowser/treebrowser.less
+++ b/src/treebrowser/treebrowser.less
@@ -20,7 +20,6 @@
                 min-width: 100%;
             }
             .tree-header-level:first-child {
-                text-align: center;
                 font-weight: bold;
                 background-color: @table-bg-accent
             }
@@ -37,6 +36,9 @@
                     width: 20px;
                     display: table-cell;
                     vertical-align: middle;
+                }
+                .custom-toggle {
+                  display: inline-block;
                 }
                 .node-content {
                     display: table-cell;

--- a/src/treebrowser/treebrowser.tpl.html
+++ b/src/treebrowser/treebrowser.tpl.html
@@ -8,7 +8,7 @@
                     <div class="content"
                          ng-style="{'padding-left': (attrs.childrenPadding || 15) + 'px'}">
                         <div class="content-holder">
-                            <div class="toggle"></div>
+                            <div></div>
                             <div class="node-content ad-user-select-none"
                                  ng-include="attrs.nodeHeaderUrl"></div>
                         </div>

--- a/src/treebrowser/treebrowserNodeToggle.tpl.html
+++ b/src/treebrowser/treebrowserNodeToggle.tpl.html
@@ -1,0 +1,11 @@
+<div class="toggle" ng-class="{'custom-toggle': attrs.customToggle}">
+    <i ng-if="!item._ad_expanded && hasChildren(item) && !item._ad_loading"
+       ng-class="iconClasses.expand"
+       ng-click="toggle($event,item)"></i>
+    <i ng-if="item._ad_expanded && !item._ad_loading"
+       ng-class="iconClasses.collapse"
+       ng-click="toggle($event,item)"></i>
+            <span ng-if="item._ad_loading">
+                <i ng-class="iconClasses.loadingSpinner"></i>
+            </span>
+</div>


### PR DESCRIPTION
This new changes allow implementation of custom toggling and hierarchical indentation of treebrowser, such as only indenting a particular cell, not entire row, avoiding shifting of adjacent cells