### PR TITLE
Fix to kill the drop element when the on-drop-leave event occurs

### DIFF
--- a/src/draggable/draggable.js
+++ b/src/draggable/draggable.js
@@ -377,6 +377,7 @@ angular.module('adaptv.adaptStrap.draggable', [])
             });
             obj.el.lastDropElement.removeClass('ad-drop-over');
             delete obj.el.lastDropElement;
+            elem = null;
           }
         }
       }


### PR DESCRIPTION
This fixes this issue https://github.com/Adaptv/adapt-strap/issues/181