### PR TITLE
Allow to prevent drag on certain child elements

### DIFF
--- a/dist/adapt-strap.js
+++ b/dist/adapt-strap.js
@@ -1,6 +1,6 @@
 /**
  * adapt-strap
- * @version v2.2.5 - 2015-05-18
+ * @version v2.2.5 - 2015-05-26
  * @link https://github.com/Adaptv/adapt-strap
  * @author Kashyap Patel (kashyap@adap.tv)
  * @license MIT License, http://www.opensource.org/licenses/MIT
@@ -235,7 +235,7 @@ angular.module('adaptv.adaptStrap.draggable', []).directive('adDrag', [
         if (!dragEnabled) {
           return;
         }
-        if ($(evt.target).is('.ad-prevent-drag')) {
+        if ($(evt.target).is('.ad-prevent-drag') || $(evt.target).parents('.ad-prevent-drag').length > 0) {
           return;
         }
         if (hasTouch) {

--- a/dist/adapt-strap.js
+++ b/dist/adapt-strap.js
@@ -235,6 +235,7 @@ angular.module('adaptv.adaptStrap.draggable', []).directive('adDrag', [
         if (!dragEnabled) {
           return;
         }
+        if ($(evt.target).is('.ad-prevent-drag')) return;
         if (hasTouch) {
           cancelPress();
           pressTimer = setTimeout(function () {

--- a/dist/adapt-strap.js
+++ b/dist/adapt-strap.js
@@ -1,6 +1,6 @@
 /**
  * adapt-strap
- * @version v2.2.5 - 2015-05-26
+ * @version v2.2.5 - 2015-05-18
  * @link https://github.com/Adaptv/adapt-strap
  * @author Kashyap Patel (kashyap@adap.tv)
  * @license MIT License, http://www.opensource.org/licenses/MIT
@@ -233,9 +233,6 @@ angular.module('adaptv.adaptStrap.draggable', []).directive('adDrag', [
       */
       function onPress(evt) {
         if (!dragEnabled) {
-          return;
-        }
-        if ($(evt.target).is('.ad-prevent-drag') || $(evt.target).parents('.ad-prevent-drag').length > 0) {
           return;
         }
         if (hasTouch) {

--- a/dist/adapt-strap.js
+++ b/dist/adapt-strap.js
@@ -235,7 +235,9 @@ angular.module('adaptv.adaptStrap.draggable', []).directive('adDrag', [
         if (!dragEnabled) {
           return;
         }
-        if ($(evt.target).is('.ad-prevent-drag')) return;
+        if ($(evt.target).is('.ad-prevent-drag')) {
+          return;
+        }
         if (hasTouch) {
           cancelPress();
           pressTimer = setTimeout(function () {

--- a/src/draggable/docs/draggable.view.html
+++ b/src/draggable/docs/draggable.view.html
@@ -49,14 +49,22 @@
         <!-- =========== Drag with handles ============= -->
         <li class="list-group-item"
             ad-drag="true"
-            ad-drag-handle="true">
+            ad-drag-handle="true"
+            id="drag-handle-demo">
           <span class="ad-drag-handle glyphicon glyphicon-align-justify"></span>
           Drag me using my handle
         </li>
         <!-- =========== Drag on the whole element ============= -->
         <li class="list-group-item"
-            ad-drag="true">
+            ad-drag="true"
+            id="drag-element-demo">
           Drag me without handle
+        </li>
+        <!-- =========== Prevent drag on parts of the element ============= -->
+        <li class="list-group-item"
+            ad-drag="true"
+            id="drag-prevent-demo">
+          Drag me, except <strong class="ad-prevent-drag">this bold text</strong></li>
         </li>
       </ul>
       <!-- ad_example_end -->

--- a/src/draggable/docs/draggable.view.html
+++ b/src/draggable/docs/draggable.view.html
@@ -64,7 +64,7 @@
         <li class="list-group-item"
             ad-drag="true"
             id="drag-prevent-demo">
-          Drag me, except <strong class="ad-prevent-drag">this bold text</strong></li>
+          Drag me, except <strong ad-prevent-drag>this bold text</strong></li>
         </li>
       </ul>
       <!-- ad_example_end -->

--- a/src/draggable/draggable.js
+++ b/src/draggable/draggable.js
@@ -89,7 +89,7 @@ angular.module('adaptv.adaptStrap.draggable', [])
         if (!dragEnabled) {
           return;
         }
-        if ($(evt.target).is('.ad-prevent-drag')) {
+        if ($(evt.target).is('.ad-prevent-drag') || $(evt.target).parents('.ad-prevent-drag').length > 0) {
           return;
         }
         if (hasTouch) {

--- a/src/draggable/draggable.js
+++ b/src/draggable/draggable.js
@@ -89,7 +89,7 @@ angular.module('adaptv.adaptStrap.draggable', [])
         if (!dragEnabled) {
           return;
         }
-        if ($(evt.target).is('.ad-prevent-drag') || $(evt.target).parents('.ad-prevent-drag').length > 0) {
+        if ($(evt.target).is('[ad-prevent-drag]') || $(evt.target).parents('[ad-prevent-drag]').length > 0) {
           return;
         }
         if (hasTouch) {

--- a/src/draggable/draggable.js
+++ b/src/draggable/draggable.js
@@ -89,7 +89,9 @@ angular.module('adaptv.adaptStrap.draggable', [])
         if (!dragEnabled) {
           return;
         }
-        if ($(evt.target).is('.ad-prevent-drag')) return;
+        if ($(evt.target).is('.ad-prevent-drag')) {
+          return;
+        }
         if (hasTouch) {
           cancelPress();
           pressTimer = setTimeout(function() {

--- a/src/draggable/draggable.js
+++ b/src/draggable/draggable.js
@@ -89,6 +89,7 @@ angular.module('adaptv.adaptStrap.draggable', [])
         if (!dragEnabled) {
           return;
         }
+        if ($(evt.target).is('.ad-prevent-drag')) return;
         if (hasTouch) {
           cancelPress();
           pressTimer = setTimeout(function() {

--- a/src/mixins.less
+++ b/src/mixins.less
@@ -76,15 +76,21 @@
 }
 
 // ========= dragdrop ========== //
-[ad-drag=true].ad-draggable {
-  cursor: move;
-}
-[ad-drag=true] > .ad-drag-handle {
-  cursor: move;
-}
+[ad-drag=true] {
+  &.ad-draggable {
+    cursor: move;
+    [ad-prevent-drag] {
+      cursor: default;
+    }
+  }
 
-[ad-drag=true].ad-dragging {
-  opacity: 0.5;
+  &> .ad-drag-handle {
+    cursor: move;
+  }
+
+  &.ad-dragging {
+    opacity: 0.5;
+  }
 }
 
 @-moz-keyframes spin {


### PR DESCRIPTION
Issue at hand (see updated doc file):

We want the user to be able to click on certain elements that are inside of a draggable element (ie. a link).

This proposed feature brings a CSS class `.ad-prevent-drag`. Adding this class on any element prevents dragging from happening.

I would happy to provide a test case, but the e2e file is completely empty at the moment.

Edit: Also added, children elements of `.ad-prevent-drag` do not trigger drag&drop.