### PR TITLE
Fix - Event propagation too wide, was preventing user interaction

### DIFF
--- a/src/draggable/draggable.js
+++ b/src/draggable/draggable.js
@@ -45,15 +45,6 @@ angular.module('adaptv.adaptStrap.draggable', [])
           element.on(startEvents, onPress);
           element.addClass('ad-draggable');
         }
-
-        if (!hasTouch) {
-          element.on('mousedown', '.ad-drag-handle', function() {
-            return false;
-          });
-          element.on('mousedown', function() {
-            return false;
-          }); // prevent native drag
-        }
       }
 
       //--- Event Handlers ---
@@ -103,6 +94,7 @@ angular.module('adaptv.adaptStrap.draggable', [])
           $document.on(endEvents, cancelPress);
         } else {
           onLongPress(evt);
+          return false;
         }
       }
 


### PR DESCRIPTION
With the previous submitted feature (`ad-prevent-drag`), even propagation was stopped before reaching the child elements.

I'm not 100% how to test for this, suggestions are welcome.