### PR TITLE
Wrong initial drag element position

### DIFF
--- a/src/draggable/draggable.js
+++ b/src/draggable/draggable.js
@@ -156,8 +156,8 @@ angular.module('adaptv.adaptStrap.draggable', [])
         mx = (evt.pageX || evt.originalEvent.touches[0].pageX);
         my = (evt.pageY || evt.originalEvent.touches[0].pageY);
 
-        tx = mx - offset.left - $window.scrollLeft();
-        ty = my - offset.top - $window.scrollTop();
+        tx = offset.left - $window.scrollLeft();
+        ty = offset.top - $window.scrollTop();
 
         persistElementWidth();
         moveElement(tx, ty);


### PR DESCRIPTION
When the user clicks on an element to drag it,  the onLongPress function positions the draggable element on the top left of the screen.After the user triggers the onMove function, the position of the draggable element is getting fixed.
You can only notice this behavior if you click on element and you wait before you start dragging it.
![dargposition](https://cloud.githubusercontent.com/assets/4030335/8162941/373bcb86-1378-11e5-8c02-f814a5fae6fa.png)
