### PR TITLE
New feature - drag clone element

### DIFF
--- a/src/draggable/draggable.js
+++ b/src/draggable/draggable.js
@@ -229,6 +229,7 @@ angular.module('adaptv.adaptStrap.draggable', [])
           callback: onDragComplete
         });
         if (scope.useClonedElement) {
+          elem.removeClass('ad-dragging');
           elem.remove();
         } else {
           elem.removeClass('ad-dragging');

--- a/src/draggable/draggable.js
+++ b/src/draggable/draggable.js
@@ -229,7 +229,7 @@ angular.module('adaptv.adaptStrap.draggable', [])
           callback: onDragComplete
         });
         if (scope.useClonedElement) {
-          elem.removeClass('ad-dragging');
+          element.removeClass('ad-dragging');
           elem.remove();
         } else {
           elem.removeClass('ad-dragging');

--- a/src/draggable/draggable.js
+++ b/src/draggable/draggable.js
@@ -156,8 +156,8 @@ angular.module('adaptv.adaptStrap.draggable', [])
         mx = (evt.pageX || evt.originalEvent.touches[0].pageX);
         my = (evt.pageY || evt.originalEvent.touches[0].pageY);
 
-        tx = mx - offset.left - $window.scrollLeft();
-        ty = my - offset.top - $window.scrollTop();
+        tx = offset.left - $window.scrollLeft();
+        ty = offset.top - $window.scrollTop();
 
         persistElementWidth();
         moveElement(tx, ty);


### PR DESCRIPTION
This pull request introduces a new optional attribute 'ad-drag-clone-element'.
When the option is defined and set to true, while dragging, a clone element will be created and dragged across instead of the original element. On drop the clone element is destroyed.

Here is a working demo of the above functionality:
http://jsfiddle.net/aq202ju9/3/