### PR TITLE
Fix ondropleave bug, remove sorting during dragdrop

### DIFF
--- a/docs/modulesDefinitions.js
+++ b/docs/modulesDefinitions.js
@@ -637,7 +637,7 @@ angular.module('adaptv.adaptStrapDocs').constant('adaptStrapModules', [
             required: 'false',
             default: 'NA',
             type: 'Function',
-            description: 'Callback for the drop end event. It fires on a valid drop. It takes 4 parameters' +
+            description: 'Callback for the drop end event. It fires only on a valid drop. It takes 4 parameters' +
               '<code>$data, $dragElement, $dropElement, $event</code>.'
           },
           {

--- a/src/draggable/docs/draggable.ctrl.js
+++ b/src/draggable/docs/draggable.ctrl.js
@@ -36,6 +36,8 @@ angular.module('adaptv.adaptStrapDocs')
       ]
     };
 
+    $scope.currentDropElement = null;
+
     $scope.remove = function(l, o) {
       var index = l.indexOf(o);
       if (index > -1) {
@@ -51,12 +53,16 @@ angular.module('adaptv.adaptStrapDocs')
 
     };
 
-    $scope.onDragOver = function() {
+    $scope.onDragOver = function(data, dragElement, dropElement) {
+      $scope.currentDropElement = dropElement;
+    };
 
+    $scope.onDragLeave = function() {
+      $scope.currentDropElement = null;
     };
 
     $scope.onDrop = function(data) {
-      if (data) {
+      if (data && $scope.currentDropElement) {
         $scope.models.basket.push(data);
         $scope.remove($scope.models.cars, data);
       }

--- a/src/draggable/docs/draggable.view.html
+++ b/src/draggable/docs/draggable.view.html
@@ -10,7 +10,7 @@
             ad-drag="true"
             ad-drag-data="car"
             ad-drag-begin="onDragStart($data, $dragElement, $event);"
-            ad-drag-end="onDataEnd($data, $dragElement, $event);"
+            ad-drag-end="onDragEnd($data, $dragElement, $lastDropElement, $event);"
             ng-repeat="car in models.cars">
           <span>
             <span class="glyphicon glyphicon-th"></span>
@@ -27,6 +27,7 @@
           class="list-group"
           ad-drop="true"
           ad-drop-over="onDragOver($data, $dragElement, $dropElement, $event);"
+          ad-drop-leave="onDragLeave($data, $dragElement, $dropElement, $event)"
           ad-drop-end="onDrop($data, $dragElement, $dropElement, $event);">
         <li class="list-group-item disabled">My Basket</li>
         <li class="list-group-item"

--- a/src/draggable/draggable.js
+++ b/src/draggable/draggable.js
@@ -321,7 +321,7 @@ angular.module('adaptv.adaptStrap.draggable', [])
 
       var dropEnabled = false;
       var elem = null;
-
+      var lastDropElement = null;
       var $window = $(window);
 
       function init() {
@@ -368,6 +368,7 @@ angular.module('adaptv.adaptStrap.draggable', [])
 
         if (el !== null) {
           elem = el;
+          lastDropElement = elem;
           obj.el.lastDropElement = elem;
           scope.$apply(function() {
             scope.onDropOverCallback(scope, {
@@ -394,29 +395,30 @@ angular.module('adaptv.adaptStrap.draggable', [])
             });
             obj.el.lastDropElement.removeClass('ad-drop-over');
             delete obj.el.lastDropElement;
-            elem = null;
+            //elem = null;
           }
         }
       }
 
       function onDragEnd(evt, obj) {
-
         if (!dropEnabled) {
           return;
         }
-
+        // call the adDrop element callback
+        // Callback should fire only once
         if (elem) {
-          // call the adDrop element callback
           scope.$apply(function () {
             scope.onDropCallback(scope, {
               $data: obj.data,
               $dragElement: { el: obj.el },
-              $dropElement: { el: elem },
+              $dropElement: { el: elem }, // Current drop element over
+              $lastDropElement: { el: lastDropElement }, // Track the previous valid drop element dragged over
               $event: evt
             });
           });
-          elem = null;
         }
+        elem = null;
+        lastDropElement = null;
       }
 
       function getCurrentDropElement(x, y) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -285,7 +285,7 @@ angular.module('adaptv.adaptStrap.utils', [])
       });
     };
   }])
-  .factory('adLoadLocalPage', ['$filter', function ($filter) {
+  .factory('adLoadLocalPage', [function () {
     return function (options) {
       var response = {
         items: undefined,
@@ -300,13 +300,13 @@ angular.module('adaptv.adaptStrap.utils', [])
         itemsObject = options.localData,
         localItems = itemsObject;
 
-      if (options.sortKey) {
+      /*if (options.sortKey) {
         localItems = $filter('orderBy')(
           itemsObject,
           options.sortKey,
           options.sortDirection
         );
-      }
+      }*/
 
       response.items = localItems.slice(start, end);
       response.allItems = itemsObject;


### PR DESCRIPTION
- Fixes on drag change issue in table lite.
- Remove Sorting, which messes up stuff during drag n drop
- Show how to use 'ad-drop-leave' to trigger actions when a valid drop element is exited