### PR TITLE
Fix - Avoid double placement of the duplicated element

### DIFF
--- a/src/draggable/draggable.js
+++ b/src/draggable/draggable.js
@@ -147,6 +147,7 @@ angular.module('adaptv.adaptStrap.draggable', [])
         evt.preventDefault();
         if (scope.useClonedElement) {
           draggedClone = element.clone().appendTo(element.parent());
+          draggedClone.css({position: 'fixed'});
         }
 
         var elem = scope.useClonedElement ? draggedClone : element;


### PR DESCRIPTION
Issue at hand:

When cloning the element, it is stacked at the bottom of the container. In our case (dragging table headers), that shifts other elements.

Down the line the element becomes `position: fixed`, but gets its width before that, which is wrong at that moment.

All the fix does is making sure the position is set earlier to make sure that `persistElementWidth` gets the proper dimensions.